### PR TITLE
feat: bump min ios version to ctss framework

### DIFF
--- a/ios/Frameworks/ctss.xcframework/ios-arm64/ctss.framework/Info.plist
+++ b/ios/Frameworks/ctss.xcframework/ios-arm64/ctss.framework/Info.plist
@@ -41,7 +41,7 @@
 	<key>DTXcodeBuild</key>
 	<string>14E300c</string>
 	<key>MinimumOSVersion</key>
-	<string>11.0</string>
+	<string>13.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/ios/Frameworks/ctss.xcframework/ios-arm64_x86_64-simulator/ctss.framework/Info.plist
+++ b/ios/Frameworks/ctss.xcframework/ios-arm64_x86_64-simulator/ctss.framework/Info.plist
@@ -41,7 +41,7 @@
 	<key>DTXcodeBuild</key>
 	<string>14E300c</string>
 	<key>MinimumOSVersion</key>
-	<string>11.0</string>
+	<string>13.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/ios/dart_2_party_ecdsa.podspec
+++ b/ios/dart_2_party_ecdsa.podspec
@@ -16,7 +16,7 @@ A convenience wrapper around corresponding rust sdk (via C bindings).
   s.source           = { :path => '.' }
   s.vendored_frameworks     = 'Frameworks/ctss.xcframework', 'Frameworks/gmp.xcframework'
   s.dependency 'Flutter'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
- bump `ctss.framework` minOSVersion to 13 to sync up with current easy crypto dependencies